### PR TITLE
Add CPU architecture support for Windows in schema and tests

### DIFF
--- a/schemas/asconfig.schema.json
+++ b/schemas/asconfig.schema.json
@@ -339,6 +339,11 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "arch": {
+              "type": "string",
+              "description": "Specifies the CPU architecture to target on Windows.",
+              "pattern": "^(x86|x64)$"
+            },
             "extdir": { "$ref": "#/definitions/airOptionsExtdir" },
             "files": { "$ref": "#/definitions/airOptionsFiles" },
             "output": { "$ref": "#/definitions/airOptionsOutput" },

--- a/src/com/as3mxml/asconfigc/AIROptionsParser.as
+++ b/src/com/as3mxml/asconfigc/AIROptionsParser.as
@@ -178,11 +178,15 @@ package com.as3mxml.asconfigc
 			{
 				setValueWithoutAssignment(AIROptions.AIR_DOWNLOAD_URL, options[platform][AIROptions.AIR_DOWNLOAD_URL], result);
 			}
+			//Android options end
+
+			//This option is commonly used for both Android and Windows
+			//Windows and Android options begin
 			if(overridesOptionForPlatform(options, AIROptions.ARCH, platform))
 			{
 				setValueWithoutAssignment(AIROptions.ARCH, options[platform][AIROptions.ARCH], result);
 			}
-			//Android options end
+			//Windows and Android options end
 
 			//NATIVE_SIGNING_OPTIONS begin
 			//these are *mobile* signing options only

--- a/test/src/tests/AIROptionsTests.as
+++ b/test/src/tests/AIROptionsTests.as
@@ -91,6 +91,19 @@ package tests
 		}
 
 		[Test]
+		public function testArchWindows():void
+		{
+			var value:String = "x64";
+			var args:Object = {};
+			args[AIRPlatformType.WINDOWS] = {}
+			args[AIRPlatformType.WINDOWS][AIROptions.ARCH] = value;
+			var result:Array = AIROptionsParser.parse(AIRPlatformType.WINDOWS, false, "application.xml", "test.swf", null, null, args);
+			var optionIndex:int = result.indexOf("-" + AIROptions.ARCH);
+			Assert.assertNotStrictlyEquals(optionIndex, -1);
+			Assert.assertStrictlyEquals(result.indexOf(value), optionIndex + 1);
+		}
+
+		[Test]
 		public function testResdir():void
 		{
 			var value:String = "path/to/res";


### PR DESCRIPTION
Hi! I'd like to contribute a small improvement.

Currently, AIR on Windows bundles as x86 by default. This PR adds an `arch`
schema option to the Windows platform configuration, allowing users to explicitly
target `x86` or `x64` architecture — the same way Android already supports it.

Changes:
- `asconfig.schema.json`: Added `arch` property to Windows air options, accepting `x86` or `x64`
- `AIROptionsParser.as`: Moved `arch` handling out of the Android-only block into a shared section for both Android and Windows
- `AIROptionsTests.as`: Added `testArchWindows` test case